### PR TITLE
Add self-contained pothole detector page

### DIFF
--- a/pothole-detector.html
+++ b/pothole-detector.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+<meta name="theme-color" content="#1b1b1f" />
+<title>Pothole Detector</title>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+  crossorigin=""
+/>
+<style>
+  :root {
+    --bg: #1b1b1f;
+    --panel: #26262c;
+    --panel-2: #303039;
+    --text: #f2f2f5;
+    --muted: #9a9aa6;
+    --accent: #ff7a3c;
+    --border: #3a3a44;
+    --low: #4caf50;
+    --med: #ffb300;
+    --high: #ff5252;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    -webkit-tap-highlight-color: transparent;
+  }
+  #app {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+    flex: 0 0 auto;
+  }
+  header h1 {
+    font-size: 18px;
+    margin: 0;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+  }
+  header .dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 4px rgba(255, 122, 60, 0.18);
+  }
+  header .count {
+    margin-left: auto;
+    font-size: 13px;
+    color: var(--muted);
+  }
+  #map {
+    flex: 1 1 auto;
+    width: 100%;
+    background: #2a2a30;
+  }
+  .controls {
+    flex: 0 0 auto;
+    background: var(--panel);
+    border-top: 1px solid var(--border);
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .status {
+    font-size: 13px;
+    color: var(--muted);
+    min-height: 18px;
+    line-height: 1.4;
+  }
+  .status.error { color: var(--high); }
+  .status.ok { color: var(--low); }
+  .row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .severity {
+    display: flex;
+    gap: 6px;
+    flex: 1 1 auto;
+  }
+  .sev-btn {
+    flex: 1;
+    padding: 10px 6px;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    color: var(--text);
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.05s ease, border-color 0.15s ease;
+  }
+  .sev-btn:active { transform: scale(0.97); }
+  .sev-btn[data-sev="low"].active { border-color: var(--low); box-shadow: inset 0 0 0 1px var(--low); }
+  .sev-btn[data-sev="medium"].active { border-color: var(--med); box-shadow: inset 0 0 0 1px var(--med); }
+  .sev-btn[data-sev="high"].active { border-color: var(--high); box-shadow: inset 0 0 0 1px var(--high); }
+  input[type="text"] {
+    flex: 1 1 auto;
+    padding: 11px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    color: var(--text);
+    font-size: 14px;
+    min-width: 0;
+  }
+  input[type="text"]::placeholder { color: var(--muted); }
+  .btn {
+    padding: 12px 16px;
+    border-radius: 10px;
+    border: none;
+    font-size: 15px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.05s ease, opacity 0.15s ease;
+  }
+  .btn:active { transform: scale(0.98); }
+  .btn-primary { background: var(--accent); color: #1b1b1f; flex: 1 1 auto; }
+  .btn-ghost { background: var(--panel-2); color: var(--text); border: 1px solid var(--border); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .footer-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .link-btn {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 4px;
+    text-decoration: underline;
+  }
+  .leaflet-popup-content { font-size: 13px; line-height: 1.5; }
+  .leaflet-popup-content b { text-transform: capitalize; }
+  .popup-del {
+    color: var(--high);
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: 600;
+  }
+  .pin {
+    width: 22px;
+    height: 22px;
+    border-radius: 50% 50% 50% 0;
+    transform: rotate(-45deg);
+    border: 2px solid rgba(0,0,0,0.4);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.5);
+  }
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <span class="dot"></span>
+    <h1>Pothole Detector</h1>
+    <span class="count" id="count">0 logged</span>
+  </header>
+  <div id="map"></div>
+  <div class="controls">
+    <div class="status" id="status">Getting your location…</div>
+    <div class="row">
+      <div class="severity">
+        <button class="sev-btn active" data-sev="low">Minor</button>
+        <button class="sev-btn" data-sev="medium">Moderate</button>
+        <button class="sev-btn" data-sev="high">Severe</button>
+      </div>
+    </div>
+    <div class="row">
+      <input type="text" id="note" placeholder="Optional note (e.g. left lane, deep)" maxlength="120" />
+    </div>
+    <div class="row">
+      <button class="btn btn-primary" id="logBtn" disabled>Log Pothole Here</button>
+      <button class="btn btn-ghost" id="locateBtn" title="Recenter">📍</button>
+    </div>
+    <div class="footer-row">
+      <span>Saved on this device only</span>
+      <span>
+        <button class="link-btn" id="exportBtn">Export JSON</button>
+        ·
+        <button class="link-btn" id="clearBtn">Clear all</button>
+      </span>
+    </div>
+  </div>
+</div>
+
+<script
+  src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+  crossorigin=""
+></script>
+<script>
+(function () {
+  "use strict";
+
+  var STORAGE_KEY = "potholes.v1";
+  var SEV = {
+    low:    { label: "Minor",    color: "#4caf50" },
+    medium: { label: "Moderate", color: "#ffb300" },
+    high:   { label: "Severe",   color: "#ff5252" }
+  };
+
+  var statusEl = document.getElementById("status");
+  var countEl = document.getElementById("count");
+  var noteEl = document.getElementById("note");
+  var logBtn = document.getElementById("logBtn");
+  var locateBtn = document.getElementById("locateBtn");
+  var exportBtn = document.getElementById("exportBtn");
+  var clearBtn = document.getElementById("clearBtn");
+
+  var currentSeverity = "low";
+  var currentPos = null;       // { lat, lng, accuracy }
+  var potholes = [];
+  var markers = {};            // id -> leaflet marker
+  var youMarker = null;
+  var accuracyCircle = null;
+  var followLocation = true;
+
+  // ---- storage ----
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      potholes = raw ? JSON.parse(raw) : [];
+      if (!Array.isArray(potholes)) potholes = [];
+    } catch (e) {
+      potholes = [];
+    }
+  }
+  function save() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(potholes));
+    } catch (e) {
+      setStatus("Could not save — storage full or blocked.", "error");
+    }
+  }
+  function updateCount() {
+    countEl.textContent = potholes.length + " logged";
+  }
+
+  // ---- status helper ----
+  function setStatus(msg, kind) {
+    statusEl.textContent = msg;
+    statusEl.className = "status" + (kind ? " " + kind : "");
+  }
+
+  // ---- map ----
+  var map = L.map("map", { zoomControl: true, attributionControl: true })
+    .setView([39.5, -98.35], 4); // center of US until we have a fix
+
+  L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map);
+
+  // dragging the map turns off auto-follow so we don't yank it back
+  map.on("dragstart", function () { followLocation = false; });
+
+  function pinIcon(color) {
+    return L.divIcon({
+      className: "",
+      html: '<div class="pin" style="background:' + color + '"></div>',
+      iconSize: [22, 22],
+      iconAnchor: [11, 22],
+      popupAnchor: [0, -20]
+    });
+  }
+
+  function fmtTime(ts) {
+    var d = new Date(ts);
+    return d.toLocaleString();
+  }
+
+  function popupHtml(p) {
+    var sev = SEV[p.severity] || SEV.low;
+    var note = p.note ? '<br>' + escapeHtml(p.note) : '';
+    return '<b style="color:' + sev.color + '">' + sev.label + '</b>' +
+      note +
+      '<br><small>' + fmtTime(p.ts) + '</small>' +
+      '<br><small>' + p.lat.toFixed(5) + ', ' + p.lng.toFixed(5) + '</small>' +
+      '<br><span class="popup-del" data-id="' + p.id + '">Delete</span>';
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function addMarker(p) {
+    var sev = SEV[p.severity] || SEV.low;
+    var m = L.marker([p.lat, p.lng], { icon: pinIcon(sev.color) }).addTo(map);
+    m.bindPopup(popupHtml(p));
+    markers[p.id] = m;
+  }
+
+  function renderAll() {
+    Object.keys(markers).forEach(function (id) {
+      map.removeLayer(markers[id]);
+    });
+    markers = {};
+    potholes.forEach(addMarker);
+    updateCount();
+  }
+
+  function deletePothole(id) {
+    potholes = potholes.filter(function (p) { return String(p.id) !== String(id); });
+    if (markers[id]) { map.removeLayer(markers[id]); delete markers[id]; }
+    save();
+    updateCount();
+  }
+
+  // delete from popup (event delegation)
+  map.on("popupopen", function (e) {
+    var node = e.popup.getElement();
+    if (!node) return;
+    var del = node.querySelector(".popup-del");
+    if (del) {
+      del.addEventListener("click", function () {
+        deletePothole(del.getAttribute("data-id"));
+        map.closePopup();
+      });
+    }
+  });
+
+  // ---- geolocation ----
+  function onPos(pos) {
+    currentPos = {
+      lat: pos.coords.latitude,
+      lng: pos.coords.longitude,
+      accuracy: pos.coords.accuracy
+    };
+    logBtn.disabled = false;
+    setStatus("Located · accuracy ±" + Math.round(currentPos.accuracy) + " m", "ok");
+
+    var ll = [currentPos.lat, currentPos.lng];
+    if (!youMarker) {
+      youMarker = L.circleMarker(ll, {
+        radius: 7, color: "#2196f3", weight: 2,
+        fillColor: "#2196f3", fillOpacity: 0.9
+      }).addTo(map).bindTooltip("You");
+      accuracyCircle = L.circle(ll, {
+        radius: currentPos.accuracy, color: "#2196f3",
+        weight: 1, fillColor: "#2196f3", fillOpacity: 0.08
+      }).addTo(map);
+      map.setView(ll, 17);
+    } else {
+      youMarker.setLatLng(ll);
+      accuracyCircle.setLatLng(ll).setRadius(currentPos.accuracy);
+      if (followLocation) map.setView(ll, map.getZoom() < 15 ? 17 : map.getZoom());
+    }
+  }
+
+  function onPosError(err) {
+    logBtn.disabled = true;
+    var msg = "Location unavailable.";
+    if (err.code === 1) msg = "Location permission denied. Enable it to log potholes.";
+    else if (err.code === 2) msg = "Position unavailable. Check GPS/signal.";
+    else if (err.code === 3) msg = "Location timed out. Retrying…";
+    setStatus(msg, "error");
+  }
+
+  function startGeo() {
+    if (!("geolocation" in navigator)) {
+      setStatus("Geolocation not supported by this browser.", "error");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(onPos, onPosError, {
+      enableHighAccuracy: true, timeout: 10000, maximumAge: 0
+    });
+    navigator.geolocation.watchPosition(onPos, onPosError, {
+      enableHighAccuracy: true, timeout: 15000, maximumAge: 2000
+    });
+  }
+
+  // ---- severity selector ----
+  document.querySelectorAll(".sev-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      document.querySelectorAll(".sev-btn").forEach(function (b) { b.classList.remove("active"); });
+      btn.classList.add("active");
+      currentSeverity = btn.getAttribute("data-sev");
+    });
+  });
+
+  // ---- log a pothole ----
+  logBtn.addEventListener("click", function () {
+    if (!currentPos) {
+      setStatus("Still waiting on a location fix…", "error");
+      return;
+    }
+    var p = {
+      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
+      lat: currentPos.lat,
+      lng: currentPos.lng,
+      accuracy: Math.round(currentPos.accuracy),
+      severity: currentSeverity,
+      note: noteEl.value.trim(),
+      ts: Date.now()
+    };
+    potholes.push(p);
+    save();
+    addMarker(p);
+    updateCount();
+    noteEl.value = "";
+    var sev = SEV[p.severity] || SEV.low;
+    setStatus("Logged " + sev.label + " pothole at " + p.lat.toFixed(5) + ", " + p.lng.toFixed(5), "ok");
+  });
+
+  // ---- recenter ----
+  locateBtn.addEventListener("click", function () {
+    followLocation = true;
+    if (currentPos) {
+      map.setView([currentPos.lat, currentPos.lng], 17);
+    } else {
+      setStatus("Getting your location…");
+      startGeo();
+    }
+  });
+
+  // ---- export ----
+  exportBtn.addEventListener("click", function () {
+    if (!potholes.length) {
+      setStatus("Nothing to export yet.", "error");
+      return;
+    }
+    var data = JSON.stringify(potholes, null, 2);
+    var blob = new Blob([data], { type: "application/json" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "potholes-" + new Date().toISOString().slice(0, 10) + ".json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+  });
+
+  // ---- clear ----
+  clearBtn.addEventListener("click", function () {
+    if (!potholes.length) return;
+    if (!confirm("Delete all " + potholes.length + " logged potholes? This cannot be undone.")) return;
+    potholes = [];
+    save();
+    renderAll();
+    setStatus("All potholes cleared.", "ok");
+  });
+
+  // ---- boot ----
+  load();
+  renderAll();
+  if (potholes.length) {
+    var last = potholes[potholes.length - 1];
+    map.setView([last.lat, last.lng], 15);
+  }
+  startGeo();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Single HTML page using Leaflet/OpenStreetMap with browser geolocation
and localStorage. Log potholes at your current GPS position with a
severity (minor/moderate/severe) and optional note; markers persist on
the device. Includes recenter, JSON export, and clear-all.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014WPTbSsxTRsdW7dBAGttHj